### PR TITLE
Add adjustable calendar settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A simple, elegant web application for creating and sharing weekly schedules. Per
 - Toggle between showing available times or busy times
 - Option to show/hide weekends
 - Gray out past days automatically
+- Adjustable number of days displayed
+- Customizable time increments
+- Change header and selection colors
 - Easy sharing via image download or clipboard copy
 - Feedback submission system
 
@@ -16,9 +19,10 @@ A simple, elegant web application for creating and sharing weekly schedules. Per
 1. Select your preferred time range using the dropdowns
 2. Click and drag on the calendar grid to select time slots
 3. Toggle between "Available Times" and "Busy Times" using the switch
-4. Use the checkboxes to customize the display (show/hide weekends, gray out past days)
-5. Click "Generate Calendar" to create your schedule image
-6. Use "Copy to Clipboard" or "Download" to share your schedule
+4. Adjust the number of days shown, time increment and colors using the settings panel
+5. Use the checkboxes to customize the display (show/hide weekends, gray out past days)
+6. Click "Generate Calendar" to create your schedule image
+7. Use "Copy to Clipboard" or "Download" to share your schedule
 
 ## Live Demo
 

--- a/index.html
+++ b/index.html
@@ -29,6 +29,32 @@
             </div>
             <button id="update-range" class="secondary-btn">Update Time Range</button>
         </div>
+        <div class="extra-settings">
+            <div class="setting">
+                <label for="num-days">Days to Show:</label>
+                <input type="number" id="num-days" min="1" max="7" value="7">
+            </div>
+            <div class="setting">
+                <label for="time-increment">Time Increment:</label>
+                <select id="time-increment">
+                    <option value="1">60 min</option>
+                    <option value="2">30 min</option>
+                    <option value="4" selected>15 min</option>
+                </select>
+            </div>
+            <div class="setting">
+                <label for="primary-color">Header Color:</label>
+                <input type="color" id="primary-color" value="#FF69B4">
+            </div>
+            <div class="setting">
+                <label for="free-color">Free Slot Color:</label>
+                <input type="color" id="free-color" value="#4CAF50">
+            </div>
+            <div class="setting">
+                <label for="busy-color">Busy Slot Color:</label>
+                <input type="color" id="busy-color" value="#FF4444">
+            </div>
+        </div>
 
         <div class="calendar-container">
             <div class="week-display">
@@ -41,15 +67,7 @@
             </div>
             <div class="grid-wrapper">
                 <div class="corner-spacer"></div>
-                <div class="weekday-labels">
-                    <div class="weekday">Mon</div>
-                    <div class="weekday">Tue</div>
-                    <div class="weekday">Wed</div>
-                    <div class="weekday">Thu</div>
-                    <div class="weekday">Fri</div>
-                    <div class="weekday">Sat</div>
-                    <div class="weekday">Sun</div>
-                </div>
+                <div class="weekday-labels"></div>
                 <div class="time-labels"></div>
                 <div class="time-grid"></div>
             </div>

--- a/script.js
+++ b/script.js
@@ -59,7 +59,13 @@ document.addEventListener('DOMContentLoaded', () => {
         grayPastDays: document.getElementById('gray-past-days'),
         feedbackText: document.getElementById('feedback-text'),
         feedbackEmail: document.getElementById('feedback-email'),
-        sendFeedbackBtn: document.getElementById('send-feedback')
+        sendFeedbackBtn: document.getElementById('send-feedback'),
+        weekdayLabels: document.querySelector('.weekday-labels'),
+        numDaysInput: document.getElementById('num-days'),
+        timeIncrement: document.getElementById('time-increment'),
+        primaryColor: document.getElementById('primary-color'),
+        freeColor: document.getElementById('free-color'),
+        busyColor: document.getElementById('busy-color')
     };
 
     const ctx = elements.canvas.getContext('2d');
@@ -148,16 +154,45 @@ document.addEventListener('DOMContentLoaded', () => {
         return dayDate < today;
     }
 
+    function applyColors() {
+        document.documentElement.style.setProperty('--primary-color', calendarConfig.style.colors.header);
+        document.documentElement.style.setProperty('--secondary-color', calendarConfig.style.colors.free);
+        document.querySelectorAll('.time-cell.selected').forEach(cell => {
+            cell.style.backgroundColor = elements.modeSwitch.checked ? calendarConfig.style.colors.busy : calendarConfig.style.colors.free;
+        });
+        if (elements.canvas.width > 0) {
+            generateCalendarImage();
+        }
+    }
+
+    function updateEnabledDays(num) {
+        calendarConfig.days.forEach((d, i) => { d.enabled = i < num; });
+    }
+
     // Create calendar grid
     function createCalendarGrid() {
         elements.timeLabels.innerHTML = '';
         elements.timeGrid.innerHTML = '';
+        elements.weekdayLabels.innerHTML = '';
 
         const startHour = parseInt(elements.startTimeSelect.value);
         const endHour = parseInt(elements.endTimeSelect.value);
         const { intervalsPerHour } = calendarConfig.timeSlots;
         const totalIntervals = (endHour - startHour) * intervalsPerHour;
         const enabledDays = getEnabledDays();
+
+        const rowHeight = 60 / intervalsPerHour;
+        elements.timeGrid.style.gridTemplateColumns = `repeat(${enabledDays.length}, 1fr)`;
+        elements.weekdayLabels.style.gridTemplateColumns = `repeat(${enabledDays.length}, 1fr)`;
+        elements.timeGrid.style.gridAutoRows = `${rowHeight}px`;
+        elements.timeLabels.style.gridTemplateRows = `repeat(${totalIntervals}, ${rowHeight}px)`;
+
+        enabledDays.forEach(day => {
+            const label = document.createElement('div');
+            label.className = 'weekday';
+            label.textContent = day.name;
+            elements.weekdayLabels.appendChild(label);
+        });
 
         // Create time labels
         for (let hour = startHour; hour <= endHour; hour++) {
@@ -184,8 +219,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 cell.className = 'time-cell';
                 cell.dataset.day = day.name;
                 cell.dataset.interval = interval;
-                cell.dataset.hour = Math.floor(interval / 4) + startHour;
-                cell.dataset.minute = (interval % 4) * 15;
+                cell.dataset.hour = Math.floor(interval / intervalsPerHour) + startHour;
+                cell.dataset.minute = (interval % intervalsPerHour) * (60 / intervalsPerHour);
                 elements.timeGrid.appendChild(cell);
             }
         }
@@ -198,8 +233,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const startHour = parseInt(elements.startTimeSelect.value);
         const endHour = parseInt(elements.endTimeSelect.value);
-        const totalIntervals = (endHour - startHour) * 4;
-        const enabledDays = getEnabledDays(true);  
+        const { intervalsPerHour } = calendarConfig.timeSlots;
+        const totalIntervals = (endHour - startHour) * intervalsPerHour;
+        const enabledDays = getEnabledDays(true);
         const style = calendarConfig.style;
         const isBusyMode = elements.modeSwitch.checked;
         const shouldGrayPastDays = elements.grayPastDays.checked;
@@ -239,7 +275,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         for (let hour = startHour; hour <= endHour; hour++) {
             if (hour < endHour || hour === startHour) {
-                const y = style.headerHeight + ((hour - startHour) * 4 * style.cellHeight);
+                const y = style.headerHeight + ((hour - startHour) * intervalsPerHour * style.cellHeight);
                 ctx.fillText(formatHour(hour), style.timeWidth - 10, y);
             }
         }
@@ -260,7 +296,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // Horizontal lines
         for (let i = 0; i <= totalIntervals; i++) {
             ctx.beginPath();
-            ctx.lineWidth = i % 4 === 0 ? 1.5 : 0.5;
+            ctx.lineWidth = i % intervalsPerHour === 0 ? 1.5 : 0.5;
             const y = style.headerHeight + (i * style.cellHeight);
             ctx.moveTo(style.timeWidth, y);
             ctx.lineTo(width, y);
@@ -288,7 +324,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const hour = parseInt(cell.dataset.hour);
             const minute = parseInt(cell.dataset.minute);
             const x = style.timeWidth + (dayIndex * style.cellSize);
-            const y = style.headerHeight + ((hour - startHour) * 4 + (minute / 15)) * style.cellHeight;
+            const y = style.headerHeight + ((hour - startHour) * intervalsPerHour + (minute / (60 / intervalsPerHour))) * style.cellHeight;
 
             // Only draw selection if it's not a past day or if past days are not being grayed out
             if (!shouldGrayPastDays || !isPastDay(calendarConfig.days.findIndex(d => d.name === dayName))) {
@@ -438,6 +474,32 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    elements.numDaysInput.addEventListener('change', () => {
+        const num = Math.min(7, Math.max(1, parseInt(elements.numDaysInput.value)));
+        elements.numDaysInput.value = num;
+        updateEnabledDays(num);
+        createCalendarGrid();
+        ctx.clearRect(0, 0, elements.canvas.width, elements.canvas.height);
+    });
+
+    elements.timeIncrement.addEventListener('change', () => {
+        calendarConfig.timeSlots.intervalsPerHour = parseInt(elements.timeIncrement.value);
+        calendarConfig.style.cellHeight = 10 * (4 / calendarConfig.timeSlots.intervalsPerHour);
+        createCalendarGrid();
+        ctx.clearRect(0, 0, elements.canvas.width, elements.canvas.height);
+    });
+
+    function updateColorConfig() {
+        calendarConfig.style.colors.header = elements.primaryColor.value;
+        calendarConfig.style.colors.free = elements.freeColor.value;
+        calendarConfig.style.colors.busy = elements.busyColor.value;
+        applyColors();
+    }
+
+    elements.primaryColor.addEventListener('input', updateColorConfig);
+    elements.freeColor.addEventListener('input', updateColorConfig);
+    elements.busyColor.addEventListener('input', updateColorConfig);
+
     elements.grayPastDays.addEventListener('change', () => {
         if (elements.canvas.width > 0) {
             generateCalendarImage();
@@ -456,4 +518,5 @@ document.addEventListener('DOMContentLoaded', () => {
     createCalendarGrid();
     updateWeekDisplay();
     elements.datePicker.value = formatDateForPicker(currentDate);
+    applyColors();
 });

--- a/styles.css
+++ b/styles.css
@@ -246,6 +246,36 @@ h1 {
     border-color: var(--secondary-color);
 }
 
+.extra-settings {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin: 1rem 0;
+}
+
+.setting {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.setting input,
+.setting select {
+    padding: 0.5rem;
+    border: 2px solid var(--primary-color);
+    border-radius: var(--border-radius);
+    background: white;
+    color: var(--text-color);
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+
+.setting input:focus,
+.setting select:focus {
+    outline: none;
+    border-color: var(--secondary-color);
+}
+
 .date-selector {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- introduce configurable days, time increments and colors
- generate weekday labels dynamically
- update styles for new settings section
- document new customization options

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684e1041f73c832cb0c1d1c049c265a2