### PR TITLE
Add configurable week start day

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,18 @@
                 <label for="busy-color">Busy Slot Color:</label>
                 <input type="color" id="busy-color" value="#FF4444">
             </div>
+            <div class="setting">
+                <label for="week-start">Week Starts On:</label>
+                <select id="week-start">
+                    <option value="1" selected>Mon</option>
+                    <option value="2">Tue</option>
+                    <option value="3">Wed</option>
+                    <option value="4">Thu</option>
+                    <option value="5">Fri</option>
+                    <option value="6">Sat</option>
+                    <option value="0">Sun</option>
+                </select>
+            </div>
         </div>
 
         <div class="calendar-container">


### PR DESCRIPTION
## Summary
- allow choosing the starting day of the week
- rotate days and compute dates based on selected start day
- reset and initialization updated for new control

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684e23f741a8832ca9b3218c8ff79fd6